### PR TITLE
Provide user agent string when downloading data

### DIFF
--- a/src/pynorare/api.py
+++ b/src/pynorare/api.py
@@ -18,7 +18,7 @@ from clldutils.source import Source
 from clldutils.apilib import API
 import pybtex.database
 
-from pynorare.files import get_mappings, get_excel, download_file
+from pynorare import files
 from pynorare.util import read_wellformed_tsv_or_die
 
 __all__ = ['NoRaRe']
@@ -130,7 +130,7 @@ class Dataset(object):
 
     def map(self, concepticon=None, mappings=None):
         if not mappings:
-            mappings, _ = get_mappings(concepticon)
+            mappings, _ = files.get_mappings(concepticon)
         self._run_function('map', concepticon, mappings)
 
     def download(self):
@@ -148,11 +148,7 @@ class Dataset(object):
         if not target:
             target = urllib.parse.urlparse(url).path.split('/')[-1]
         if (not self.raw_dir.joinpath(target).exists()) or overwrite:
-            try:
-                urllib.request.urlretrieve(url, str(self.raw_dir / target))
-            except urllib.error.HTTPError:  # pragma: no cover
-                # Try with requests:
-                download_file(url, self.raw_dir / target)
+            files.download_file(url, self.raw_dir / target)
             self.log.info('Downloaded {0} successfully.'.format(url))
         return self.raw_dir / target
 
@@ -161,7 +157,7 @@ class Dataset(object):
         return list(reader(self.raw_dir / path, delimiter=delimiter, dicts=dicts, encoding=coding))
 
     def get_excel(self, path, sidx=0, dicts=True):
-        sheet = get_excel(self.raw_dir.joinpath(path), sidx, dicts)
+        sheet = files.get_excel(self.raw_dir.joinpath(path), sidx, dicts)
         self.log.info('load data from {0}'.format(path))
         return sheet
 

--- a/src/pynorare/files.py
+++ b/src/pynorare/files.py
@@ -6,6 +6,7 @@ from pyconcepticon import Concepticon
 import xlrd
 import openpyxl
 
+import pynorare
 from pynorare.util import read_wellformed_tsv_or_die
 
 
@@ -39,7 +40,8 @@ def get_excel(path, sheet_index, dicts=False):
 
 
 def download_file(url, path):  # pragma: no cover
-    request = Request(url, headers={'User-Agent': 'norare/1.1.0'})
+    user_agent = f'norare/{pynorare.__version__}'
+    request = Request(url, headers={'User-Agent': user_agent})
     with urlopen(request) as response:
         with open(path, 'wb') as fp:
             while (chunk := response.read(8192)):

--- a/src/pynorare/files.py
+++ b/src/pynorare/files.py
@@ -1,6 +1,6 @@
 import collections
+from urllib.request import Request, urlopen
 
-import requests
 from cldfcatalog import Config
 from pyconcepticon import Concepticon
 import xlrd
@@ -39,10 +39,9 @@ def get_excel(path, sheet_index, dicts=False):
 
 
 def download_file(url, path):  # pragma: no cover
-    headers = {'User-Agent': 'norare/1.1.0'}
-    with requests.get(url, headers=headers, stream=True) as r:
-        r.raise_for_status()
-        with path.open('wb') as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                f.write(chunk)
+    request = Request(url, headers={'User-Agent': 'norare/1.1.0'})
+    with urlopen(request) as response:
+        with open(path, 'wb') as fp:
+            while (chunk := response.read(8192)):
+                fp.write(chunk)
     return path

--- a/src/pynorare/files.py
+++ b/src/pynorare/files.py
@@ -39,7 +39,8 @@ def get_excel(path, sheet_index, dicts=False):
 
 
 def download_file(url, path):  # pragma: no cover
-    with requests.get(url, stream=True) as r:
+    headers = {'User-Agent': 'norare/1.1.0'}
+    with requests.get(url, headers=headers, stream=True) as r:
         r.raise_for_status()
         with path.open('wb') as f:
             for chunk in r.iter_content(chunk_size=8192):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,8 +16,8 @@ def test_NoRaRe(api):
 
 def test_Dataset_download_zip(api, mocker):
     mocker.patch(
-        'pynorare.api.urllib.request',
-        mocker.Mock(urlretrieve=lambda u, t: 1))
+        'pynorare.api.files.download_file',
+        sideeffect=lambda _url, path: path)
     ds = api.datasets['ds2']
     ds.download_zip('x', 'f.zip', 'norare.xlsx')
     assert len(ds.get_excel('norare.xlsx')) == 2

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ def test_NoRaRe(api):
 def test_Dataset_download_zip(api, mocker):
     mocker.patch(
         'pynorare.api.files.download_file',
-        sideeffect=lambda _url, path: path)
+        side_effect=lambda _url, path: path)
     ds = api.datasets['ds2']
     ds.download_zip('x', 'f.zip', 'norare.xlsx')
     assert len(ds.get_excel('norare.xlsx')) == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,19 +27,29 @@ def test_stats(_main, capsys):
     assert out.strip().startswith('No.')
 
 
+def make_pretend_data(_url, path):
+    data = (
+        'gloss,float,int,POS\n'
+        'the gloss,1.2,3,noun\n'
+        'other gloss,1.2,3')
+    pathlib.Path(path).write_text(data, encoding='utf-8')
+    return path
+
+
 def test_workflow(_main, mocker):
-    mocker.patch(
-        'pynorare.api.urllib.request',
-        mocker.Mock(urlretrieve=lambda u, f: pathlib.Path(f).write_text(
-            'gloss,float,int,POS\nthe gloss,1.2,3,noun\nother gloss,1.2,3', encoding='utf8')))
+    mock_impl = mocker.patch(
+        'pynorare.api.files.download_file',
+        sideeffect=make_pretend_data)
     _main('download', 'dsid')
+    mock_impl.assert_called_once()
     _main('map', 'dsid')
     _main('validate', 'dsid')
 
-    mocker.patch(
-        'pynorare.api.urllib.request',
-        mocker.Mock(urlretrieve=lambda u, t: 1))
+    mock_impl = mocker.patch(
+        'pynorare.api.files.download_file',
+        sideeffect=lambda _url, path: path)
     _main('download', 'ds2')
+    mock_impl.assert_called_once()
     _main('map', 'ds2')
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,28 +28,27 @@ def test_stats(_main, capsys):
 
 
 def make_pretend_data(_url, path):
-    data = (
-        'gloss,float,int,POS\n'
-        'the gloss,1.2,3,noun\n'
-        'other gloss,1.2,3')
-    pathlib.Path(path).write_text(data, encoding='utf-8')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(
+            'gloss,float,int,POS\n'
+            'the gloss,1.2,3,noun\n'
+            'other gloss,1.2,3')
     return path
 
 
 def test_workflow(_main, mocker):
-    mock_impl = mocker.patch(
+    mock_download = mocker.patch(
         'pynorare.api.files.download_file',
-        sideeffect=make_pretend_data)
+        side_effect=make_pretend_data)
     _main('download', 'dsid')
-    mock_impl.assert_called_once()
+    mock_download.assert_called_once()
     _main('map', 'dsid')
     _main('validate', 'dsid')
 
-    mock_impl = mocker.patch(
+    mocker.patch(
         'pynorare.api.files.download_file',
-        sideeffect=lambda _url, path: path)
+        side_effect=lambda _url, path: path)
     _main('download', 'ds2')
-    mock_impl.assert_called_once()
     _main('map', 'ds2')
 
 


### PR DESCRIPTION
Okay, @MiraAhmedovic reported a case where downloading a data set failed because the server required the request to provide a user agent string (Seems like it doesn't care what the user agent is as long as it gets one).

I just set the user agent to `norare/1.1.0`.  Seemed resonable enough to me.

However, this PR is still incomplete.  Fixing the code itself took me only a few minutes if at all but then I got stuck for over an hour trying to get the tests to work.  I can't for the life of me figure out how to get `pytest` to run my mock implementation of the download function.

https://github.com/concepticon/pynorare/blob/23d177826943ca3c69b4064d738ecef74524bd3e/tests/test_cli.py#L40-L44

`norare download` seems to succeed and *assert\_called\_once* passes, so the function seems to *run*.  But then `norare map` fails because the placeholder file isn't actually there…  So, something seems to eat the side effects or something?

@xrotwang @lingulist Also, do you remember the reason why the old code tries download the data using the stdlib and then falls back to *requests*?  Are there ever any cases where those yield different results?
